### PR TITLE
Add support for adding Option values

### DIFF
--- a/src/test/scala/org/clapper/scalasti/StringTemplate.scala
+++ b/src/test/scala/org/clapper/scalasti/StringTemplate.scala
@@ -225,6 +225,21 @@ class StringTemplateTest extends FunSuite {
     assert(None === st.attribute[Int]("s"))
   }
 
+  test("Optional String typed attribute retrieval") {
+    val st = ST("<s>")
+    st.add("s", Some("foo"))
+    assert(st.render() === "foo")
+    assert(Some("foo") === st.attribute[String]("s"))
+  }
+
+  test("None typed attribute retrieval") {
+    val st = ST("<s>")
+    st.add("s", None)
+    assert(st.render() === "")
+    assert(None === st.attribute[AnyRef]("s"))
+    assert(None === st.attribute[String]("s"))
+  }
+
   test("Custom typed attribute retrieval") {
     val groupString =
       """


### PR DESCRIPTION
Should help fix #7. I'm not much of a Scala expert, so feel free to tear this approach apart.

When converting to Java, one of two things will happen:
  1. If the value is `None`, `null` will be passed to the template
  2. If the value is `Some(x)`, `x` will be converted to a Java type as usual