### PR TITLE
Makes registerRenderer callable multiple times

### DIFF
--- a/src/main/scala/org/clapper/scalasti/STGroupDir.scala
+++ b/src/main/scala/org/clapper/scalasti/STGroupDir.scala
@@ -14,22 +14,7 @@ import scala.util.{Failure, Success, Try}
   * the companion object.
   */
 class STGroupDir private[scalasti](native: _STGroupDir)
-  extends STGroup(native = native) {
-
-  /** Create a new underlying StringTemplate object, applying whatever
-    * constructor parameters were used with the current object. Does not
-    * apply the attrRenderers.
-    *
-    * Subclasses should override this method.
-    *
-    * @return the new underlying object
-    */
-  override protected[this] def newUnderlying: _STGroupDir = {
-    new _STGroupDir(native.root,
-                    native.encoding,
-                    native.delimiterStartChar,
-                    native.delimiterStopChar)
-  }
+  extends STGroup(native = native, newUnderlying = STGroupDir.newUnderlying(native)) {
 
   /** Force a load. Templates are normally loaded on demand; this method
     * attempts to load them up front. '''Note''': Even though this method
@@ -134,4 +119,17 @@ object STGroupDir {
           startDelimiter,
           endDelimiter)
   }
+
+  /** Create a new underlying StringTemplate object, applying whatever
+    * constructor parameters were used with the current object. Does not
+    * apply the attrRenderers.
+    *
+    * @return the new underlying object
+    */
+  private[scalasti] def newUnderlying(native: _STGroupDir): () => _STGroupDir =
+    () => new _STGroupDir(
+      native.root,
+      native.encoding,
+      native.delimiterStartChar,
+      native.delimiterStopChar)
 }

--- a/src/main/scala/org/clapper/scalasti/STGroupFile.scala
+++ b/src/main/scala/org/clapper/scalasti/STGroupFile.scala
@@ -13,23 +13,7 @@ import org.stringtemplate.v4.misc.ErrorManager
   * methods on the companion object.
   */
 class STGroupFile private[scalasti](native: _STGroupFile)
-  extends STGroup(native = native) {
-
-  /** Create a new underlying StringTemplate object, applying whatever
-    * constructor parameters were used with the current object. Does not
-    * apply the attrRenderers.
-    *
-    * Subclasses should override this method.
-    *
-    * @return the new underlying object
-    */
-  override protected[this] def newUnderlying: _STGroup = {
-    new _STGroupFile(native.url,
-                     native.encoding,
-                     native.delimiterStartChar,
-                     native.delimiterStopChar)
-  }
-}
+  extends STGroup(native = native, newUnderlying = STGroupFile.newUnderlying(native))
 
 /** Companion object for `STGroupFile`. This object provides `apply()`
   * methods for instantiating `STGroupFile` objects.
@@ -137,4 +121,17 @@ object STGroupFile {
                                   endDelimiter)
     new STGroupFile(native)
   }
+
+  /** Create a new underlying StringTemplate object, applying whatever
+    * constructor parameters were used with the current object. Does not
+    * apply the attrRenderers.
+    *
+    * @return the new underlying object
+    */
+  private[scalasti] def newUnderlying(native: _STGroupFile): () => _STGroupFile =
+    () => new _STGroupFile(
+      native.url,
+      native.encoding,
+      native.delimiterStartChar,
+      native.delimiterStopChar)
 }

--- a/src/main/scala/org/clapper/scalasti/STGroupString.scala
+++ b/src/main/scala/org/clapper/scalasti/STGroupString.scala
@@ -10,23 +10,7 @@ import org.stringtemplate.v4.{STGroupString => _STGroupString}
   * methods on the companion object.
   */
 class STGroupString private[scalasti](native: _STGroupString)
-  extends STGroup(native = native) {
-
-  /** Create a new underlying StringTemplate object, applying whatever
-    * constructor parameters were used with the current object. Does not
-    * apply the attrRenderers.
-    *
-    * Subclasses should override this method.
-    *
-    * @return the new underlying object
-    */
-  override protected[this] def newUnderlying: _STGroupString = {
-    new _STGroupString(native.sourceName,
-                       native.text,
-                       native.delimiterStartChar,
-                       native.delimiterStopChar)
-  }
-}
+  extends STGroup(native = native, newUnderlying = STGroupString.newUnderlying(native))
 
 /** Companion object for `STGroupString`. This object provides `apply()`
   * methods for instantiating `STGroupString` objects.
@@ -54,4 +38,17 @@ object STGroupString {
                                     endDelimiter)
     new STGroupString(native)
   }
+
+  /** Create a new underlying StringTemplate object, applying whatever
+    * constructor parameters were used with the current object. Does not
+    * apply the attrRenderers.
+    *
+    * @return the new underlying object
+    */
+  private[scalasti] def newUnderlying(native: _STGroupString): () => _STGroupString =
+    () => new _STGroupString(
+      native.sourceName,
+      native.text,
+      native.delimiterStartChar,
+      native.delimiterStopChar)
 }

--- a/src/test/scala/org/clapper/scalasti/BaseSpec.scala
+++ b/src/test/scala/org/clapper/scalasti/BaseSpec.scala
@@ -2,6 +2,7 @@ package org.clapper.scalasti
 
 import org.scalatest.{FlatSpec, Matchers}
 import java.io._
+import java.util.Locale
 
 import grizzled.file.util.{dirname, joinPath, withTemporaryDirectory}
 import grizzled.util.withResource
@@ -13,6 +14,11 @@ case class TemplateGroupFileData(path:        String,
                                  groupString: String,
                                  templates:   Seq[TemplateData])
 case class TemplateGroupDirData(path: String, templates: Seq[TemplateData])
+
+// Can't register attrRenderers for primitive types.
+class FloatWrapper(val f: Float)
+class IntWrapper(val i: Int)
+
 
 /** Base class for testers
   */
@@ -102,6 +108,19 @@ abstract class BaseSpec extends FlatSpec with Matchers with CustomMatchers {
       code(STGroupDir(groupPath.getPath))
     }
   }
+
+  val floatRenderer = new AttributeRenderer[FloatWrapper] {
+    def toString(o: FloatWrapper, formatString: String, local: Locale): String = {
+      o.f.toString
+    }
+  }
+
+  val intRenderer = new AttributeRenderer[IntWrapper] {
+    def toString(o: IntWrapper, formatString: String, local: Locale): String = {
+      o.i.toString
+    }
+  }
+
 
   // --------------------------------------------------------------------------
   // Private methods

--- a/src/test/scala/org/clapper/scalasti/STGroupDirSpec.scala
+++ b/src/test/scala/org/clapper/scalasti/STGroupDirSpec.scala
@@ -61,6 +61,19 @@ class STGroupDirSpec extends BaseSpec {
     }
   }
 
+  it should "allow adding multiple attribute renderers without losing templates" in {
+    withTemplateGroupDir(TemplateGroupDir) { grp =>
+      val t = grp.load()
+      t shouldBe 'success
+      val grp2 = grp
+        .registerRenderer(floatRenderer)
+        .registerRenderer(intRenderer)
+
+      grp2.instanceOf("foo") shouldBe 'success
+      grp2.fileName shouldBe grp.fileName
+    }
+  }
+
   it should "succeed when attempting to find a valid template" in {
     withTemplateGroupDir(TemplateGroupDir) { grp =>
       val tTemplate = grp.instanceOf("foo")

--- a/src/test/scala/org/clapper/scalasti/STGroupFileSpec.scala
+++ b/src/test/scala/org/clapper/scalasti/STGroupFileSpec.scala
@@ -1,11 +1,7 @@
 package org.clapper.scalasti
 
 import java.net.URL
-import java.util.Locale
 
-
-// Can't register attrRenderers for primitive types.
-class FloatWrapper(val f: Float)
 
 /** Tests for STGroup class
   */
@@ -92,16 +88,21 @@ class STGroupFileSpec extends BaseSpec {
   }
 
   "registerRenderer()" should "be immutable" in {
-    val newRenderer = new AttributeRenderer[FloatWrapper] {
-      def toString(o: FloatWrapper, formatString: String, local: Locale): String = {
-        o.f.toString
-      }
-    }
-
     withTemplateGroupFile(TemplateGroup1) { stGroup =>
-      val stGroup2 = stGroup.registerRenderer(newRenderer)
+      val stGroup2 = stGroup.registerRenderer(floatRenderer)
       stGroup2 should not be theSameInstanceAs (stGroup)
       stGroup2.attrRenderers should not be theSameInstanceAs (stGroup.attrRenderers)
+    }
+  }
+
+  "registerRenderer()" should "not lose templates on multiple calls" in {
+    withTemplateGroupFile(TemplateGroup1) { stGroup =>
+      val stGroup2 = stGroup
+        .registerRenderer(floatRenderer)
+        .registerRenderer(intRenderer)
+
+      stGroup2.instanceOf("foo") shouldBe 'success
+      stGroup2.fileName shouldBe stGroup.fileName
     }
   }
 

--- a/src/test/scala/org/clapper/scalasti/STGroupStringSpec.scala
+++ b/src/test/scala/org/clapper/scalasti/STGroupStringSpec.scala
@@ -47,4 +47,12 @@ class STGroupStringSpec extends BaseSpec {
 
     template2 should renderSuccessfullyAs (s"FOO='${args.mkString(",")}'")
   }
+
+  it should "allow adding multiple attribute renderers without losing templates" in {
+    val grp = STGroupString(TemplateGroup1)
+      .registerRenderer(floatRenderer)
+      .registerRenderer(intRenderer)
+
+    grp.instanceOf("foo") shouldBe 'success
+  }
 }


### PR DESCRIPTION
The underlying subclass was being lost by STGroup after the first call
was made to registerRenderer. This passes a function to create a new
underlying group instead of using inheritence.